### PR TITLE
Add `require()` to usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Next see the [react native linking guide](https://facebook.github.io/react-nativ
 #use
 See the [noble](https://github.com/sandeepmistry/noble/) api for usage
 ```
-var noble = ('react-native-ble');
+var noble = require('react-native-ble');
 ```
 
 Better yet, as in the example, include as noble 
 ```
-var noble = ('noble');
+var noble = require('noble');
 ```
 And in your package json resolve noble to react native
 ```


### PR DESCRIPTION
I'm new to React Native so might be missing something, but I needed to have the `require()` call that was removed in 7224890b9ba4c051d620d3fa290a980899a66d52 in order for this to work.