### PR TITLE
Remove standard iOS powered-off alert.

### DIFF
--- a/RNBLE.m
+++ b/RNBLE.m
@@ -25,7 +25,7 @@ RCT_EXPORT_MODULE()
   if (self = [super init]) {
     centralEventQueue = dispatch_queue_create("com.openble.mycentral", DISPATCH_QUEUE_SERIAL);
     dispatch_set_target_queue(centralEventQueue, dispatch_get_main_queue());
-    centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:centralEventQueue options:@{ CBCentralManagerOptionRestoreIdentifierKey:@"myCentralManagerIdentifier" }];
+    centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:centralEventQueue options:@{ CBCentralManagerOptionRestoreIdentifierKey:@"myCentralManagerIdentifier" CBCentralManagerOptionShowPowerAlertKey: @NO }];
 
     peripherals = [NSMutableDictionary new];
   }
@@ -539,15 +539,15 @@ RCT_EXPORT_METHOD(notify:(NSString *)peripheralUuid serviceUuid:(NSString *)serv
 - (NSDictionary *)dictionaryForAdvertisementData:(NSDictionary *)advertisementData fromPeripheral:(CBPeripheral *)peripheral
 {
   NSMutableDictionary *advertisement = [NSMutableDictionary new];
-  
+
   if (advertisementData[CBAdvertisementDataLocalNameKey] != nil) {
     advertisement[@"localName"] = advertisementData[CBAdvertisementDataLocalNameKey];
   }
-  
+
   if (advertisementData[CBAdvertisementDataManufacturerDataKey] != nil) {
     advertisement[@"manufacturerData"] = [advertisementData[CBAdvertisementDataManufacturerDataKey] base64EncodedStringWithOptions:0];
   }
-  
+
   if (advertisementData[CBAdvertisementDataServiceDataKey] != nil) {
     advertisement[@"serviceData"] = [NSMutableArray new];
     for (CBUUID *uuid in advertisementData[CBAdvertisementDataServiceDataKey]) {
@@ -557,32 +557,32 @@ RCT_EXPORT_METHOD(notify:(NSString *)peripheralUuid serviceUuid:(NSString *)serv
                              }];
     }
   }
-  
+
   if (advertisementData[CBAdvertisementDataServiceUUIDsKey] != nil) {
     advertisement[@"serviceUuids"] = [NSMutableArray new];
     for (CBUUID *uuid in advertisementData[CBAdvertisementDataServiceUUIDsKey]) {
       [advertisement[@"serviceUuids"] addObject:[self toNobleUuid:uuid.UUIDString]];
     }
   }
-  
+
   if (advertisementData[CBAdvertisementDataOverflowServiceUUIDsKey] != nil) {
     advertisement[@"overflowServiceUuids"] = [NSMutableArray new];
     for (CBUUID *uuid in advertisementData[CBAdvertisementDataOverflowServiceUUIDsKey]) {
       [advertisement[@"overflowServiceUuids"] addObject:[self toNobleUuid:uuid.UUIDString]];
     }
   }
-  
+
   if (advertisementData[CBAdvertisementDataTxPowerLevelKey] != nil) {
     advertisement[@"txPowerLevel"] = advertisementData[CBAdvertisementDataTxPowerLevelKey];
   }
-  
+
   if (advertisementData[CBAdvertisementDataSolicitedServiceUUIDsKey] != nil) {
     advertisement[@"solicitedServiceUuids"] = [NSMutableArray new];
     for (CBUUID *uuid in advertisementData[CBAdvertisementDataSolicitedServiceUUIDsKey]) {
       [advertisement[@"solicitedServiceUuids"] addObject:[self toNobleUuid:uuid.UUIDString]];
     }
   }
-  
+
   return advertisement;
 }
 
@@ -600,7 +600,7 @@ RCT_EXPORT_METHOD(notify:(NSString *)peripheralUuid serviceUuid:(NSString *)serv
 - (NSString *)NSStringForCBCentralManagerState:(CBCentralManagerState)state
 {
   NSString *stateString = [NSString new];
-  
+
   switch (state) {
     case CBCentralManagerStateResetting:
       stateString = @"resetting";


### PR DESCRIPTION
This removes the standard ios bluetooth is powered off alert (Turn on bluetooth to allow "App Name" to connect to accessories)

Developers can handle this case using noble.on('stateChange',
callback(state)); instead. This is an improvement because it moves the decision of how to handle this case to the javascript. 