### PR TITLE
Add a new method to enable bluetooth manually for android

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ See the [noble](https://github.com/sandeepmistry/noble/) api for usage
 var noble = ('react-native-ble');
 ```
 
+Use `noble.enable()` in order to raise a dialog that requests user permission to turn on Bluetooth.
+
 For more advanced usage, like in the eddystone_beacon_scanner, include noble directly or utilize a package that does so:
 ```
 var noble = ('noble');

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,5 +19,5 @@ android {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:23.1.0'
-    compile 'com.facebook.react:react-native:0.14.+'
+    compile 'com.facebook.react:react-native:[0.29.0,)'
 }

--- a/android/src/main/java/com/geniem/rnble/RNBLEModule.java
+++ b/android/src/main/java/com/geniem/rnble/RNBLEModule.java
@@ -31,6 +31,8 @@ import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
 
+import android.content.Intent;
+
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
@@ -146,6 +148,14 @@ class RNBLEModule extends ReactContextBaseJavaModule implements LifecycleEventLi
         if(bluetoothLeScanner != null && scanCallback != null){
             bluetoothLeScanner.stopScan(scanCallback);
             scanCallback = null;            
+        }
+    }
+
+    @ReactMethod
+    public void enable() {
+        if (bluetoothAdapter != null && !bluetoothAdapter.isEnabled()) {
+            Intent intentEnable = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
+            getCurrentActivity().startActivity(intentEnable);
         }
     }
 

--- a/bindings.android.js
+++ b/bindings.android.js
@@ -117,6 +117,10 @@ nobleBindings.stopScanning = function() {
   this.emit('scanStop');
 };
 
+nobleBindings.enable = function() {
+    RNBLE.enable();
+};
+
 nobleBindings.discoverServices = function(deviceUuid, uuids) {
   RNBLE.discoverServices(deviceUuid, toAppleUuids(uuids));
 };

--- a/bindings.ios.js
+++ b/bindings.ios.js
@@ -163,6 +163,9 @@ nobleBindings.disconnect = function(deviceUuid) {
   this.RNBLE.disconnect(toAppleUuid(deviceUuid));
 };
 
+nobleBindings.enable = function() {
+};
+
 nobleBindings.updateRssi = function(deviceUuid) {
   this.RNBLE.updateRssi(toAppleUuid(deviceUuid));
 };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,8 @@
-var noble = require('noble/with-bindings');
+var Noble = require('noble/lib/noble');
 var bindings = require('./bindings');
-module.exports = new noble(bindings);
+
+Noble.prototype.enable = function () {
+    this._bindings.enable();
+}
+
+module.exports = new Noble(bindings);


### PR DESCRIPTION
When using Android and this module, there is no way to make the user enable bluetooth with a dialog.

I really missed this feature, so here are two patches:
1. The first one updates the react-native dependency version to inherit the `getCurrentActivity` method in the module
2. This adds the actual `enable` method to raise the bluetooth dialog. It also extends the Noble prototype to add the method as it is not in the api

I understand the consequences of such a patch because first it forces the use of react-native >= 0.29 and it also adds a method which is not part of Noble.

However, in android this is really necessary if bluetooth is disabled, usually users don't want to exit the app to go in the settings.
