### PR TITLE
Fix reload issue

### DIFF
--- a/RNBLE.m
+++ b/RNBLE.m
@@ -18,7 +18,23 @@ RCT_EXPORT_MODULE()
 
 @synthesize bridge = _bridge;
 
++ (RNBLE *)sharedManager
+{
+  static RNBLE *sharedManager;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedManager = [[self alloc] init];
+  });
+
+  return sharedManager;
+}
+
 #pragma mark Initialization
+
++ (RNBLE *)new {
+
+  return [RNBLE sharedManager];
+}
 
 - (instancetype)init
 {

--- a/RNBLE.m
+++ b/RNBLE.m
@@ -26,13 +26,14 @@ RCT_EXPORT_MODULE()
     sharedManager = [[self alloc] init];
   });
 
+  [sharedManager dropAllConnections];
+
   return sharedManager;
 }
 
 #pragma mark Initialization
 
 + (RNBLE *)new {
-
   return [RNBLE sharedManager];
 }
 
@@ -46,6 +47,12 @@ RCT_EXPORT_MODULE()
     peripherals = [NSMutableDictionary new];
   }
   return self;
+}
+
+- (void) dropAllConnections {
+  for (CBPeripheral *peripheral in [peripherals objectEnumerator]) {
+    [centralManager cancelPeripheralConnection:peripheral];
+  }
 }
 
 RCT_EXPORT_METHOD(startScanning:(CBUUIDArray *)uuids allowDuplicates:(BOOL)allowDuplicates)


### PR DESCRIPTION
Hi there! Thanks for this library. 

This fixes an issue where reloading the React Native app (from the developer menu) would cause Noble's state to be "unsupported" due reinitializing `RNBLE` / `CBCentralManager`. This makes `RNBLE` a singleton and ensures that React Native will always be accessing that singleton by overriding `new`.

Another side-effect was that the JavaScript Noble object would fall out of sync and connections were still maintained, so we drop all connections whenever the singleton is accessed, to ensure a fresh BLE state.

Would love to hear thoughts as there are probably cases I'm not considering here. Thanks!