### PR TITLE
Return all characteristics if none were passed

### DIFF
--- a/android/src/main/java/com/geniem/rnble/RNBLEModule.java
+++ b/android/src/main/java/com/geniem/rnble/RNBLEModule.java
@@ -277,6 +277,13 @@ class RNBLEModule extends ReactContextBaseJavaModule implements LifecycleEventLi
                             }
                         }
                     }                    
+                } else {
+                  Iterator<BluetoothGattCharacteristic> iterator = characteristics.iterator();
+
+                  while(iterator.hasNext()){
+                    BluetoothGattCharacteristic characteristic = iterator.next();
+                    filteredCharacteristics.add(characteristic);
+                  }
                 }
 
                 //process characteristics 


### PR DESCRIPTION
On Android there's an option to pass `characteristicUuids` which is used
to return the characteristics that were found. If none are passed then
no characteristics are returned.

This adds an else condition for when `charactersticUuids` are null or
empty to return all characteristics.